### PR TITLE
Fixing email and password login method when user already has an account

### DIFF
--- a/lib/modules/login/bloc/login_bloc.dart
+++ b/lib/modules/login/bloc/login_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:zenith_monitor/modules/login/screen/login_screen.dart';
 import 'package:zenith_monitor/utils/mixins/class_local_user.dart';

--- a/lib/modules/login/bloc/login_event.dart
+++ b/lib/modules/login/bloc/login_event.dart
@@ -25,9 +25,14 @@ class EmailLoginEvent extends AuthenticationEvent {
 
   @override
   Future<LocalUser> getUser() async {
-    await UserStorage().uploadImage();
+    UserDocument userDocument = UserDocument(authMethod: auth);
+    DocumentSnapshot? userDocSnap =
+        await userDocument.getUserFirebaseDocument();
+    if (userDocSnap == null) {
+      await UserStorage().uploadImage();
+    }
 
-    return await UserDocument().getUserFirestore(auth);
+    return await userDocument.getUserFirestore(userDocSnap);
   }
 }
 
@@ -41,7 +46,10 @@ class GoogleLoginEvent extends AuthenticationEvent {
 
   @override
   Future<LocalUser> getUser() async {
-    return await UserDocument().getUserFirestore(auth);
+    UserDocument userDocument = UserDocument(authMethod: auth);
+    DocumentSnapshot? userDocSnap =
+        await userDocument.getUserFirebaseDocument();
+    return await userDocument.getUserFirestore(userDocSnap);
   }
 }
 


### PR DESCRIPTION
Before this commit, if an user already has an account and downloads the app again, he won't be able to login because his local json file would not exist. Now, the user dosen't need to have and json file to login.


<!--PS: 🇧🇷/🇬🇧 It's ok to write your PR in portuguese 😃-->

## What type of PR is this? (check all applicable)
- [ ] ✨ Feature
- [x] 🐞 Bug Correction
- [ ] 📝 Documentation Update
- [ ] 🚩 Other



